### PR TITLE
feat: capture uncaught exceptions and unhandled Promise rejections in browser logs

### DIFF
--- a/docs/docs/playwright-web/Supported-Tools.mdx
+++ b/docs/docs/playwright-web/Supported-Tools.mdx
@@ -209,7 +209,7 @@ Execute JavaScript in the browser console.
 
 ### Playwright_console_logs
 Retrieve console logs from the browser with filtering options
-Supports Retrieval of logs like - all, error, warning, log, info, debug
+Supports Retrieval of logs like - all, error, warning, log, info, debug, exception
 
 - **`search`** *(string)*:  
   Text to search for in logs (handles text with square brackets).
@@ -218,7 +218,7 @@ Supports Retrieval of logs like - all, error, warning, log, info, debug
   Maximum number of logs to retrieve.
 
 - **`type`** *(string)*:
-  Type of logs to retrieve (all, error, warning, log, info, debug).
+  Type of logs to retrieve (all, error, warning, log, info, debug, exception).
 
 - **`clear`** *(boolean)*:
   Whether to clear logs after retrieval (default: false).

--- a/docs/docs/release.mdx
+++ b/docs/docs/release.mdx
@@ -73,6 +73,7 @@ are supported.[More Detail available here](/docs/playwright-web/Console-Logging)
   - `warn`
   - `error`
   - `debug`
+  - `exception`
   - `all`
 
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -187,8 +187,8 @@ export function createToolDefinitions() {
         properties: {
           type: {
             type: "string",
-            description: "Type of logs to retrieve (all, error, warning, log, info, debug)",
-            enum: ["all", "error", "warning", "log", "info", "debug"]
+            description: "Type of logs to retrieve (all, error, warning, log, info, debug, exception)",
+            enum: ["all", "error", "warning", "log", "info", "debug", "exception"]
           },
           search: {
             type: "string",


### PR DESCRIPTION
### Solution
This PR enhances the MCP browser log system by:

- Listening for `pageerror` to capture uncaught exceptions in the browser runtime.
- Injecting a `window.addEventListener("unhandledrejection")` listener via `addInitScript()` to catch unhandled Promise rejections.
- Routing all captured errors through `consoleLogsTool.registerConsoleMessage()` for consistent handling.